### PR TITLE
refactor(test-form): rename fields, simplify schema, and update UI integration

### DIFF
--- a/app/test/layout.tsx
+++ b/app/test/layout.tsx
@@ -13,7 +13,7 @@ const TestLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <div className="mx-auto w-full max-w-screen-2xl px-4 md:px-8 lg:px-14">
-      <header className="fixed top-0 right-0 left-0 z-10 mx-auto w-full max-w-screen-2xl">
+      <header className="fixed top-0 right-0 left-0 z-20 mx-auto w-full max-w-screen-2xl">
         <div className="border-primary bg-background flex flex-col items-start gap-4 border-b px-4 pt-12 pb-6 md:px-8 lg:flex-row lg:items-center lg:justify-between lg:px-14">
           <h1 className="text-[clamp(1.5rem,5vw,2.3rem)] font-bold text-white">
             {title}

--- a/features/test/components/base-form.tsx
+++ b/features/test/components/base-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import React, { useEffect, useMemo, useCallback } from "react";
 import {
   FormField,
   FormItem,
@@ -11,7 +11,12 @@ import {
 import { useFormContext } from "react-hook-form";
 import { Input } from "@/components/ui/input";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { DIFFICULTIES, TEST_TYPES, TIME_TYPES } from "@/types/test";
+import {
+  ALLOW_REPETITION,
+  DIFFICULTIES,
+  TEST_TYPES,
+  TIME_TYPES,
+} from "@/types/test";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { formatTimeLabel } from "../../../helpers/format-time-label";
 import { Label } from "@/components/ui/label";
@@ -22,26 +27,99 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { z } from "zod";
+
+const HOURS_OPTIONS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES_OPTIONS = Array.from({ length: 60 }, (_, i) => i);
+const SECONDS_OPTIONS = Array.from({ length: 60 }, (_, i) => i);
 
 const BaseForm = () => {
-  const { control, formState } = useFormContext();
+  const { control, formState, watch, setValue } = useFormContext();
 
-  const isTimeError =
-    !!formState.errors.hours ||
-    !!formState.errors.minutes ||
-    !!formState.errors.seconds;
+  const timerMode = watch("timer_mode");
+  const allowRepetition = watch("allow_repetition");
+
+  const isTimerDisabled = useMemo(() => timerMode === "notimer", [timerMode]);
+
+  const { isTimeError, timerErrorMessage } = useMemo(() => {
+    const timerSettingsErrors = formState.errors.timer_settings;
+
+    if (!timerSettingsErrors || typeof timerSettingsErrors !== "object") {
+      return { isTimeError: false, timerErrorMessage: "" };
+    }
+
+    const hasError = !!(
+      "hours" in timerSettingsErrors ||
+      "minutes" in timerSettingsErrors ||
+      "seconds" in timerSettingsErrors
+    );
+
+    const errors = timerSettingsErrors as Record<string, z.ZodIssue>;
+    const message =
+      errors.hours?.message?.toString() ||
+      errors.minutes?.message?.toString() ||
+      errors.seconds?.message?.toString() ||
+      "";
+
+    return { isTimeError: hasError, timerErrorMessage: message };
+  }, [formState.errors.timer_settings]);
+
+  const handleDifficultyChange = useCallback((val: string) => {
+    if (val) return val;
+  }, []);
+
+  const handleTestTypeChange = useCallback((val: string) => {
+    if (val) return val;
+  }, []);
+
+  const handleRepetitionChange = useCallback((val: string) => {
+    if (val) return val === "true";
+  }, []);
+
+  const handleShuffleChange = useCallback((val: string) => {
+    if (val) return val === "true";
+  }, []);
+
+  const handleNumberInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      return value ? parseInt(value) : undefined;
+    },
+    [],
+  );
+
+  const createSelectHandler = useCallback(
+    (fieldOnChange: (value: number) => void) => (value: string) => {
+      fieldOnChange(Number(value));
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!allowRepetition) {
+      setValue("max_repetition_count", undefined, { shouldValidate: true });
+    }
+  }, [allowRepetition, setValue]);
+
+  useEffect(() => {
+    if (isTimerDisabled) {
+      setValue("timer_settings.hours", 0, { shouldValidate: true });
+      setValue("timer_settings.minutes", 0, { shouldValidate: true });
+      setValue("timer_settings.seconds", 0, { shouldValidate: true });
+    }
+  }, [isTimerDisabled, setValue]);
 
   return (
     <section className="flex flex-col gap-8 md:flex-row md:justify-between">
       {/* Base Form */}
-      <div className="flex w-full max-w-screen-sm flex-col space-y-6">
-        {/* Name Field */}
+      <div className="flex w-full max-w-screen-md flex-col space-y-6 md:max-w-screen-sm">
+        {/* Title Field */}
         <FormField
           control={control}
-          name="name"
+          name="title"
           render={({ field }) => (
             <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-4">
-              <FormLabel className="w-32 font-semibold text-white">
+              <FormLabel className="w-36 font-semibold text-white">
                 Test Title
               </FormLabel>
               <div className="w-full flex-1 space-y-2">
@@ -64,7 +142,7 @@ const BaseForm = () => {
           name="description"
           render={({ field }) => (
             <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-4">
-              <FormLabel className="w-32 font-semibold text-white">
+              <FormLabel className="w-36 font-semibold text-white">
                 Test Description
               </FormLabel>
               <div className="w-full flex-1 space-y-2">
@@ -87,7 +165,7 @@ const BaseForm = () => {
           name="difficulty"
           render={({ field }) => (
             <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-0">
-              <FormLabel className="w-32 font-semibold text-white">
+              <FormLabel className="w-36 font-semibold text-white">
                 Difficulty Level
               </FormLabel>
               <FormControl className="flex-1 md:max-w-sm">
@@ -95,7 +173,8 @@ const BaseForm = () => {
                   type="single"
                   value={field.value}
                   onValueChange={(val) => {
-                    if (val) field.onChange(val);
+                    const result = handleDifficultyChange(val);
+                    if (result) field.onChange(result);
                   }}
                   className="flex w-full gap-2 rounded-4xl border border-[#FFFFFF66] md:w-fit"
                 >
@@ -119,10 +198,10 @@ const BaseForm = () => {
         {/* Type */}
         <FormField
           control={control}
-          name="typeTest"
+          name="type_test"
           render={({ field }) => (
             <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-0">
-              <FormLabel className="w-32 font-semibold text-white">
+              <FormLabel className="w-36 font-semibold text-white">
                 Type
               </FormLabel>
               <FormControl className="flex-1 md:max-w-sm">
@@ -130,9 +209,10 @@ const BaseForm = () => {
                   type="single"
                   value={field.value}
                   onValueChange={(val) => {
-                    if (val) field.onChange(val);
+                    const result = handleTestTypeChange(val);
+                    if (result) field.onChange(result);
                   }}
-                  className="flex w-full gap-2 rounded-4xl border border-[#FFFFFF66] md:w-fit"
+                  className="flex w-full gap-2 rounded-4xl border border-[#FFFFFF66] md:max-w-xs lg:max-w-sm"
                 >
                   {TEST_TYPES.map((item) => (
                     <ToggleGroupItem
@@ -150,6 +230,113 @@ const BaseForm = () => {
             </FormItem>
           )}
         />
+
+        {/* Allow Repetition */}
+        <FormField
+          control={control}
+          name="allow_repetition"
+          render={({ field }) => (
+            <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-0">
+              <FormLabel className="w-36 font-semibold text-white">
+                Allow Repetition
+              </FormLabel>
+              <FormControl className="flex-1 md:max-w-sm">
+                <ToggleGroup
+                  type="single"
+                  value={field.value ? "true" : "false"}
+                  onValueChange={(val) => {
+                    const result = handleRepetitionChange(val);
+                    if (typeof result === "boolean") field.onChange(result);
+                  }}
+                  className="flex w-full gap-2 rounded-4xl border border-[#FFFFFF66] md:max-w-xs lg:max-w-sm"
+                >
+                  {ALLOW_REPETITION.map((item) => (
+                    <ToggleGroupItem
+                      key={item.label}
+                      value={item.value.toString()}
+                      aria-label={item.label}
+                      className="data-[state=on]:bg-primary rounded-full px-3 py-2 transition-colors data-[state=on]:text-white"
+                    >
+                      {item.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Max Repetition Count - Only show if allow_repetition is true */}
+        {allowRepetition && (
+          <FormField
+            control={control}
+            name="max_repetition_count"
+            render={({ field }) => (
+              <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-4">
+                <FormLabel className="w-36 font-semibold text-white">
+                  Max Repetitions
+                </FormLabel>
+                <div className="w-full flex-1 space-y-2">
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min="1"
+                      variant="underline"
+                      placeholder="Enter max repetition count"
+                      {...field}
+                      value={field.value || ""}
+                      onChange={(e) => {
+                        const result = handleNumberInputChange(e);
+                        field.onChange(result);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          />
+        )}
+
+        {/* Shuffle Questions */}
+        <FormField
+          control={control}
+          name="settings.shuffle_questions"
+          render={({ field }) => (
+            <FormItem className="flex flex-col items-start justify-start gap-6 lg:flex-row lg:items-center lg:gap-0">
+              <FormLabel className="w-36 font-semibold text-white">
+                Shuffle Questions
+              </FormLabel>
+              <FormControl className="flex-1 md:max-w-sm">
+                <ToggleGroup
+                  type="single"
+                  value={field.value ? "true" : "false"}
+                  onValueChange={(val) => {
+                    const result = handleShuffleChange(val);
+                    if (typeof result === "boolean") field.onChange(result);
+                  }}
+                  className="flex w-full gap-2 rounded-4xl border border-[#FFFFFF66] md:max-w-xs lg:max-w-sm"
+                >
+                  {[
+                    { label: "Yes", value: true },
+                    { label: "No", value: false },
+                  ].map((item) => (
+                    <ToggleGroupItem
+                      key={item.label}
+                      value={item.value.toString()}
+                      aria-label={item.label}
+                      className="data-[state=on]:bg-primary rounded-full px-3 py-2 transition-colors data-[state=on]:text-white"
+                    >
+                      {item.label}
+                    </ToggleGroupItem>
+                  ))}
+                </ToggleGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
       </div>
 
       {/* Time Settings */}
@@ -158,7 +345,7 @@ const BaseForm = () => {
         <div className="flex flex-col items-start justify-between gap-4 lg:flex-row">
           <FormField
             control={control}
-            name="timeType"
+            name="timer_mode"
             render={({ field }) => (
               <FormItem className="space-y-3">
                 <FormControl>
@@ -189,6 +376,8 @@ const BaseForm = () => {
               </FormItem>
             )}
           />
+
+          {/* Timer inputs */}
           <div className="flex items-center gap-2">
             {/* Hours */}
             <div className="flex w-[80px] flex-col items-center gap-2">
@@ -197,22 +386,25 @@ const BaseForm = () => {
               </Label>
               <FormField
                 control={control}
-                name="hours"
+                name="timer_settings.hours"
                 render={({ field }) => (
                   <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
+                    onValueChange={createSelectHandler(field.onChange)}
+                    value={field.value?.toString() || "0"}
                   >
                     <FormControl>
-                      <SelectTrigger className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none">
+                      <SelectTrigger
+                        className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none"
+                        disabled={isTimerDisabled}
+                      >
                         <SelectValue placeholder="HH" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {Array.from({ length: 24 }).map((_, i) => (
+                      {HOURS_OPTIONS.map((i) => (
                         <SelectItem
                           key={i}
-                          value={i.toString().padStart(2, "0")}
+                          value={i.toString()}
                           className="text-sm"
                         >
                           {i.toString().padStart(2, "0")}
@@ -233,22 +425,25 @@ const BaseForm = () => {
               </Label>
               <FormField
                 control={control}
-                name="minutes"
+                name="timer_settings.minutes"
                 render={({ field }) => (
                   <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
+                    onValueChange={createSelectHandler(field.onChange)}
+                    value={field.value?.toString() || "0"}
                   >
                     <FormControl>
-                      <SelectTrigger className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none">
+                      <SelectTrigger
+                        className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none"
+                        disabled={isTimerDisabled}
+                      >
                         <SelectValue placeholder="MM" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {Array.from({ length: 60 }).map((_, i) => (
+                      {MINUTES_OPTIONS.map((i) => (
                         <SelectItem
                           key={i}
-                          value={i.toString().padStart(2, "0")}
+                          value={i.toString()}
                           className="text-sm"
                         >
                           {i.toString().padStart(2, "0")}
@@ -269,22 +464,25 @@ const BaseForm = () => {
               </Label>
               <FormField
                 control={control}
-                name="seconds"
+                name="timer_settings.seconds"
                 render={({ field }) => (
                   <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
+                    onValueChange={createSelectHandler(field.onChange)}
+                    value={field.value?.toString() || "0"}
                   >
                     <FormControl>
-                      <SelectTrigger className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none">
+                      <SelectTrigger
+                        className="rounded-md border border-white/30 bg-white/10 px-3 py-1 text-white focus:ring-2 focus:ring-white/50 focus:outline-none"
+                        disabled={isTimerDisabled}
+                      >
                         <SelectValue placeholder="SS" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {Array.from({ length: 60 }).map((_, i) => (
+                      {SECONDS_OPTIONS.map((i) => (
                         <SelectItem
                           key={i}
-                          value={i.toString().padStart(2, "0")}
+                          value={i.toString()}
                           className="text-sm"
                         >
                           {i.toString().padStart(2, "0")}
@@ -297,12 +495,9 @@ const BaseForm = () => {
             </div>
           </div>
         </div>
+
         {isTimeError && (
-          <div className="text-destructive text-sm">
-            {formState.errors.hours?.message?.toString() ||
-              formState.errors.minutes?.message?.toString() ||
-              formState.errors.seconds?.message?.toString()}
-          </div>
+          <div className="text-destructive text-sm">{timerErrorMessage}</div>
         )}
       </div>
     </section>

--- a/features/test/form/create-listening-form.ts
+++ b/features/test/form/create-listening-form.ts
@@ -1,4 +1,4 @@
-import { baseTestSchema, withTimeValidation } from "@/validators/test";
+import { baseTestSchema, withAllValidations } from "@/validators/test";
 import { z } from "zod";
 
 // const questionSchema = z.discriminatedUnion("type", [
@@ -16,7 +16,7 @@ const passageSchema = z.object({
   questionGroups: z.array(questionGroupSchema).min(1, "Minimal 1 grup soal"),
 });
 
-export const createListeningTestSchema = withTimeValidation(
+export const createListeningTestSchema = withAllValidations(
   baseTestSchema.extend({
     passages: z.array(passageSchema).min(1, "At least one passage is required"),
   }),

--- a/features/test/form/create-reading-form.ts
+++ b/features/test/form/create-reading-form.ts
@@ -1,4 +1,4 @@
-import { baseTestSchema, withTimeValidation } from "@/validators/test";
+import { baseTestSchema, withAllValidations } from "@/validators/test";
 import { z } from "zod";
 
 export const QuestionType = z.enum([
@@ -216,7 +216,7 @@ const passageSchema = z.object({
   questionGroups: z.array(questionGroupSchema).min(1, "Minimal 1 grup soal"),
 });
 
-export const createReadingTestSchema = withTimeValidation(
+export const createReadingTestSchema = withAllValidations(
   baseTestSchema.extend({
     passages: z.array(passageSchema).min(1, "At least one passage is required"),
   }),

--- a/features/test/pages/create-listening-test.tsx
+++ b/features/test/pages/create-listening-test.tsx
@@ -17,15 +17,24 @@ const CreateListeningTestPage = () => {
   const form = useForm<CreateListeningTestSchema>({
     resolver: zodResolver(createListeningTestSchema),
     defaultValues: {
-      name: "",
+      title: "",
       description: "",
       difficulty: "beginner",
-      timeType: "notimer",
-      type: "listening",
-      typeTest: "single",
-      hours: "00",
-      minutes: "00",
-      seconds: "00",
+      timer_mode: "notimer",
+      type_test: "single",
+      type: "reading",
+      timer_settings: {
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      },
+      allow_repetition: false,
+      max_repetition_count: undefined,
+      is_public: false,
+      is_published: false,
+      settings: {
+        shuffle_questions: false,
+      },
     },
   });
 

--- a/features/test/pages/create-reading-test.tsx
+++ b/features/test/pages/create-reading-test.tsx
@@ -18,15 +18,24 @@ const CreateReadingTestPage = () => {
   const form = useForm<CreateReadingTestSchema>({
     resolver: zodResolver(createReadingTestSchema),
     defaultValues: {
-      name: "",
+      title: "",
       description: "",
       difficulty: "beginner",
-      timeType: "notimer",
-      typeTest: "single",
+      timer_mode: "notimer",
+      type_test: "single",
       type: "reading",
-      hours: "00",
-      minutes: "00",
-      seconds: "00",
+      timer_settings: {
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      },
+      allow_repetition: false,
+      max_repetition_count: undefined,
+      is_public: false,
+      is_published: false,
+      settings: {
+        shuffle_questions: false,
+      },
       passages: [
         {
           title: "",

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,6 +1,11 @@
 export const DIFFICULTIES = ["beginner", "intermediate", "advanced"] as const;
 export const TIME_TYPES = ["countup", "countdown", "notimer"] as const;
 export const TEST_TYPES = ["single", "final"] as const;
+export const TYPE = ["listening", "reading", "writing", "speaking"] as const;
+export const ALLOW_REPETITION = [
+  { label: "Yes", value: true },
+  { label: "No", value: false },
+] as const;
 
 export type Difficulty = (typeof DIFFICULTIES)[number];
 export type TimeType = (typeof TIME_TYPES)[number];

--- a/validators/test.ts
+++ b/validators/test.ts
@@ -1,49 +1,56 @@
 import { z } from "zod";
-import { DIFFICULTIES, TEST_TYPES, TIME_TYPES } from "@/types/test";
+import { DIFFICULTIES, TEST_TYPES, TIME_TYPES, TYPE } from "@/types/test";
 
 export const baseTestSchema = z.object({
-  name: z.string().min(1, "Name is required"),
+  title: z.string().min(1, "Title is required"),
   description: z.string().min(1, "Description is required"),
   difficulty: z.enum(DIFFICULTIES, {
     errorMap: () => ({ message: "Difficulty must be selected" }),
   }),
-  timeType: z.enum(TIME_TYPES, {
+  timer_mode: z.enum(TIME_TYPES, {
     errorMap: () => ({ message: "Time type must be selected" }),
   }),
-  type: z.enum(["listening", "reading", "writing", "speaking"], {
+  type: z.enum(TYPE, {
     errorMap: () => ({ message: "Type must be selected" }),
   }),
-  typeTest: z.enum(TEST_TYPES, {
-    errorMap: () => ({ message: "Type must be selected" }),
+  type_test: z.enum(TEST_TYPES, {
+    errorMap: () => ({ message: "Type test must be selected" }),
   }),
-  hours: z.string().default("0"),
-  minutes: z.string().default("0"),
-  seconds: z.string().default("0"),
+  timer_settings: z.object({
+    hours: z.number().int().min(0).default(0),
+    minutes: z.number().int().min(0).max(59).default(0),
+    seconds: z.number().int().min(0).max(59).default(0),
+  }),
+  allow_repetition: z.boolean().default(false),
+  max_repetition_count: z.number().optional(),
+  is_public: z.boolean().default(false),
+  is_published: z.boolean().default(false),
+  settings: z.object({
+    shuffle_questions: z.boolean().default(false),
+  }),
 });
 
-// Utility: validasi durasi waktu berdasarkan `timeType`
+// Utility: validasi durasi waktu berdasarkan `timer_mode`
 export const withTimeValidation = <T extends z.ZodTypeAny>(schema: T) =>
   schema.superRefine((data: z.infer<T>, ctx) => {
-    const hours = Number(data.hours || "0");
-    const minutes = Number(data.minutes || "0");
-    const seconds = Number(data.seconds || "0");
+    const { hours, minutes, seconds } = data.timer_settings;
     const totalSeconds = hours * 3600 + minutes * 60 + seconds;
 
-    const isCountdown = data.timeType === "countdown";
-    const isCountup = data.timeType === "countup";
-    const isNoTimer = data.timeType === "notimer";
+    const isCountdown = data.timer_mode === "countdown";
+    const isCountup = data.timer_mode === "countup";
+    const isNoTimer = data.timer_mode === "notimer";
 
     if ((isCountdown || isCountup) && totalSeconds === 0) {
       ctx.addIssue({
-        path: ["hours"],
+        path: ["timer_settings", "hours"],
         code: z.ZodIssueCode.custom,
-        message: "Duration must be more than 00:00:00 for this time type.",
+        message: "Duration must be more than 0:00:00 for this timer mode.",
       });
     }
 
     if ((isCountdown || isCountup) && minutes > 59) {
       ctx.addIssue({
-        path: ["minutes"],
+        path: ["timer_settings", "minutes"],
         code: z.ZodIssueCode.custom,
         message: "Minutes cannot exceed 59",
       });
@@ -51,21 +58,46 @@ export const withTimeValidation = <T extends z.ZodTypeAny>(schema: T) =>
 
     if ((isCountdown || isCountup) && seconds > 59) {
       ctx.addIssue({
-        path: ["seconds"],
+        path: ["timer_settings", "seconds"],
         code: z.ZodIssueCode.custom,
         message: "Seconds cannot exceed 59",
       });
     }
 
     if (isNoTimer && totalSeconds > 0) {
-      ctx.addIssue({
-        path: ["hours"],
-        code: z.ZodIssueCode.custom,
-        message: "Time must be 00:00:00 if using 'No Timer'",
-      });
+      // Reset timer settings to 0 when no timer is selected
+      data.timer_settings = {
+        hours: 0,
+        minutes: 0,
+        seconds: 0,
+      };
     }
   });
 
-// Final base schema
-export const generalCreateTestSchema = withTimeValidation(baseTestSchema);
+// Utility: validasi repetition berdasarkan `allow_repetition`
+export const withRepetitionValidation = <T extends z.ZodTypeAny>(schema: T) =>
+  schema.superRefine((data: z.infer<T>, ctx) => {
+    // Jika allow_repetition true, maka max_repetition_count wajib ada dan > 0
+    if (data.allow_repetition) {
+      if (!data.max_repetition_count || data.max_repetition_count <= 0) {
+        ctx.addIssue({
+          path: ["max_repetition_count"],
+          code: z.ZodIssueCode.custom,
+          message:
+            "Max repetition count is required and must be greater than 0 when repetition is allowed",
+        });
+      }
+    } else {
+      // Jika allow_repetition false, set max_repetition_count ke undefined
+      data.max_repetition_count = undefined;
+    }
+  });
+
+// Combined validation utility untuk di-apply ke extended schemas
+export const withAllValidations = <T extends z.ZodTypeAny>(schema: T) =>
+  withRepetitionValidation(withTimeValidation(schema));
+
+// General schema dengan semua validasi (untuk standalone use)
+export const generalCreateTestSchema = withAllValidations(baseTestSchema);
+
 export type GeneralCreateTestSchema = z.infer<typeof generalCreateTestSchema>;


### PR DESCRIPTION
- Renamed schema fields for consistency (`title` → `name`, `timer_mode` → `timeType`, `type_test` → `typeTest`)
- Flattened `timer_settings` object into individual `hours`, `minutes`, and `seconds` fields
- Updated time validation logic to match new schema shape
- Removed unused constants and streamlined enums
- Applied schema changes to UI form bindings and validation