### PR TITLE
Fix-toolbar

### DIFF
--- a/features/test/components/question-image.tsx
+++ b/features/test/components/question-image.tsx
@@ -184,9 +184,9 @@ const QuestionImage = ({
   const [selectedImages, setSelectedImages] = useState<ImageItem[]>([]);
   const previousDialogState = useRef<boolean>(false);
 
-  // Load existing images from context only when context changes
+  // Load existing images from context only when dialog opens
   useEffect(() => {
-    if (currentContext && Array.isArray(currentContext)) {
+    if (isDialogOpen && currentContext && Array.isArray(currentContext)) {
       const loadedImages: ImageItem[] = [];
       currentContext.forEach((item, index) => {
         if (item instanceof File) {
@@ -198,10 +198,10 @@ const QuestionImage = ({
         }
       });
       setSelectedImages(loadedImages);
-    } else {
+    } else if (isDialogOpen) {
       setSelectedImages([]);
     }
-  }, [currentContext]);
+  }, [isDialogOpen, currentContext]);
 
   // Handle dialog close/open changes
   useEffect(() => {
@@ -286,6 +286,26 @@ const QuestionImage = ({
     setIsDialogOpen(false);
   }, [selectedImages, setValue, imagePath, setIsDialogOpen]);
 
+  const handleCancelDialog = useCallback(() => {
+    // Reset to original state
+    if (currentContext && Array.isArray(currentContext)) {
+      const loadedImages: ImageItem[] = [];
+      currentContext.forEach((item, index) => {
+        if (item instanceof File) {
+          loadedImages.push({
+            id: `existing-${index}`,
+            file: item,
+            previewUrl: URL.createObjectURL(item),
+          });
+        }
+      });
+      setSelectedImages(loadedImages);
+    } else {
+      setSelectedImages([]);
+    }
+    onDialogOpenChange(false);
+  }, [currentContext, onDialogOpenChange]);
+
   const handleDialogContentClick = (e: React.MouseEvent) => {
     // Prevent dialog from closing when clicking inside dialog content
     e.stopPropagation();
@@ -332,7 +352,7 @@ const QuestionImage = ({
           </p>
         </div>
 
-        {/* Selected Images Preview using ImagePreview component */}
+        {/* FIXED: Selected Images Preview - show all selected images */}
         <ImagePreview
           images={selectedFiles}
           onRemove={handleRemoveImage}
@@ -342,17 +362,15 @@ const QuestionImage = ({
           containerClassName="max-h-60 grid-cols-2 md:grid-cols-3"
         />
 
-        {/* Current Images Display (from form context) using ImagePreview component */}
-        {selectedImages.length === 0 && (
-          <ImagePreview
-            images={currentContext}
-            title="Current Images"
-            onRemove={handleRemoveImage}
-            onClearAll={handleClearAll}
-            containerClassName="max-h-60 grid-cols-2 md:grid-cols-3"
-            showActions={true}
-          />
-        )}
+        {/* Show current saved images info */}
+        {currentContext &&
+          Array.isArray(currentContext) &&
+          currentContext.length > 0 &&
+          selectedImages.length === 0 && (
+            <div className="text-sm text-gray-400">
+              Current saved images: {currentContext.length} image(s)
+            </div>
+          )}
 
         {/* Action Buttons */}
         <div className="flex flex-col items-center justify-between gap-4 pt-4 md:flex-row">
@@ -365,16 +383,11 @@ const QuestionImage = ({
               type="button"
               size="xsm"
               variant="outline"
-              onClick={() => onDialogOpenChange(false)}
+              onClick={handleCancelDialog}
             >
               Cancel
             </Button>
-            <Button
-              type="button"
-              size="xsm"
-              onClick={handleSaveImages}
-              disabled={selectedImages.length === 0}
-            >
+            <Button type="button" size="xsm" onClick={handleSaveImages}>
               Save Images ({selectedImages.length})
             </Button>
           </div>

--- a/features/test/components/question-image.tsx
+++ b/features/test/components/question-image.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 import { useToolbarStore } from "@/store/toolbar-store";
 import { Upload, X } from "lucide-react";
 import Image from "next/image";
@@ -25,6 +26,148 @@ interface ImageItem {
   file: File;
   previewUrl: string;
 }
+
+export const ImagePreview = ({
+  images,
+  onClearAll,
+  onRemove,
+  showActions,
+  className,
+  containerClassName,
+  itemClassName,
+  title,
+}: {
+  images: File[] | undefined;
+  onRemove?: (index: number) => void;
+  onClearAll?: () => void;
+  showActions?: boolean;
+  containerClassName?: string;
+  className?: string;
+  itemClassName?: string;
+  title?: string;
+}) => {
+  const [imageItems, setImageItems] = useState<ImageItem[]>([]);
+
+  useEffect(() => {
+    if (images && Array.isArray(images)) {
+      const items: ImageItem[] = images.map((file, index) => ({
+        id: `preview-${index}-${file.name}`,
+        file,
+        previewUrl: URL.createObjectURL(file),
+      }));
+      setImageItems(items);
+
+      // Cleanup function
+      return () => {
+        items.forEach((item) => {
+          URL.revokeObjectURL(item.previewUrl);
+        });
+      };
+    } else {
+      setImageItems([]);
+    }
+  }, [images]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      imageItems.forEach((item) => {
+        URL.revokeObjectURL(item.previewUrl);
+      });
+    };
+  }, [imageItems]);
+
+  const handleRemoveImage = useCallback(
+    (index: number) => {
+      if (onRemove) {
+        onRemove(index);
+      }
+    },
+    [onRemove],
+  );
+
+  const handleClearAll = useCallback(() => {
+    if (onClearAll) {
+      onClearAll();
+    }
+  }, [onClearAll]);
+
+  // Don't render if no images
+  if (!images || !Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center justify-between">
+        <Label>
+          {title || `Images`} ({images.length})
+        </Label>
+        {showActions && onClearAll && (
+          <Button
+            type="button"
+            variant="outline"
+            size="xsm"
+            onClick={handleClearAll}
+          >
+            <X className="mr-1 h-4 w-4" />
+            Clear All
+          </Button>
+        )}
+      </div>
+
+      <div
+        className={cn(
+          "grid gap-4 overflow-y-auto rounded-lg p-2",
+          containerClassName,
+        )}
+      >
+        {imageItems.map((imageItem, index) => (
+          <div key={imageItem.id} className="group relative">
+            <div
+              className={
+                (cn(
+                  "aspect-square overflow-hidden rounded-lg border-2 border-dashed border-gray-300",
+                ),
+                itemClassName)
+              }
+            >
+              <Image
+                width={150}
+                height={150}
+                src={imageItem.previewUrl}
+                alt={`Preview ${imageItem.file.name}`}
+                className="h-full w-full object-cover"
+                onError={() => {
+                  console.error(`Failed to load image: ${imageItem.file.name}`);
+                }}
+              />
+            </div>
+
+            {showActions && onRemove && (
+              <Button
+                type="button"
+                variant="destructive"
+                size="iconSm"
+                className="absolute -top-2 -right-2 h-6 w-6 rounded-full p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                onClick={() => handleRemoveImage(index)}
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
+
+            <div className="absolute right-0 bottom-0 left-0 truncate bg-black/50 p-1 text-xs text-white">
+              {imageItem.file.name}
+            </div>
+            <div className="mt-1 text-center text-xs text-gray-500">
+              {(imageItem.file.size / 1024).toFixed(1)} KB
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 const QuestionImage = ({
   isDialogOpen,
@@ -110,13 +253,13 @@ const QuestionImage = ({
     e.target.value = "";
   };
 
-  const handleRemoveImage = useCallback((id: string) => {
+  const handleRemoveImage = useCallback((index: number) => {
     setSelectedImages((prev) => {
-      const imageToRemove = prev.find((img) => img.id === id);
+      const imageToRemove = prev[index];
       if (imageToRemove && imageToRemove.previewUrl.startsWith("blob:")) {
         URL.revokeObjectURL(imageToRemove.previewUrl);
       }
-      return prev.filter((img) => img.id !== id);
+      return prev.filter((_, i) => i !== index);
     });
   }, []);
 
@@ -147,6 +290,9 @@ const QuestionImage = ({
     // Prevent dialog from closing when clicking inside dialog content
     e.stopPropagation();
   };
+
+  // Convert selectedImages to File array for ImagePreview
+  const selectedFiles = selectedImages.map((item) => item.file);
 
   return (
     <DialogContent
@@ -186,102 +332,30 @@ const QuestionImage = ({
           </p>
         </div>
 
-        {/* Selected Images Preview */}
-        {selectedImages.length > 0 && (
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <Label>Selected Images ({selectedImages.length})</Label>
-              <Button
-                type="button"
-                variant="outline"
-                size="xsm"
-                onClick={handleClearAll}
-              >
-                <X className="mr-1 h-4 w-4" />
-                Clear All
-              </Button>
-            </div>
-            <div className="grid max-h-60 grid-cols-2 gap-4 overflow-y-auto rounded-lg p-2 md:grid-cols-3">
-              {selectedImages.map((imageItem) => (
-                <div key={imageItem.id} className="group relative">
-                  <div className="aspect-square overflow-hidden rounded-lg border-2 border-dashed border-gray-300">
-                    <Image
-                      width={150}
-                      height={150}
-                      src={imageItem.previewUrl}
-                      alt={`Preview ${imageItem.file.name}`}
-                      className="h-full w-full object-cover"
-                      onError={() => {
-                        console.error(
-                          `Failed to load image: ${imageItem.file.name}`,
-                        );
-                      }}
-                    />
-                  </div>
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    size="iconSm"
-                    className="absolute -top-2 -right-2 h-6 w-6 rounded-full p-0 opacity-0 transition-opacity group-hover:opacity-100"
-                    onClick={() => handleRemoveImage(imageItem.id)}
-                  >
-                    <X className="h-3 w-3" />
-                  </Button>
-                  <div className="absolute right-0 bottom-0 left-0 truncate bg-black/50 p-1 text-xs text-white">
-                    {imageItem.file.name}
-                  </div>
-                  <div className="mt-1 text-center text-xs text-gray-500">
-                    {(imageItem.file.size / 1024).toFixed(1)} KB
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+        {/* Selected Images Preview using ImagePreview component */}
+        <ImagePreview
+          images={selectedFiles}
+          onRemove={handleRemoveImage}
+          onClearAll={handleClearAll}
+          showActions={true}
+          title="Selected Images"
+          containerClassName="max-h-60 grid-cols-2 md:grid-cols-3"
+        />
+
+        {/* Current Images Display (from form context) using ImagePreview component */}
+        {selectedImages.length === 0 && (
+          <ImagePreview
+            images={currentContext}
+            title="Current Images"
+            onRemove={handleRemoveImage}
+            onClearAll={handleClearAll}
+            containerClassName="max-h-60 grid-cols-2 md:grid-cols-3"
+            showActions={true}
+          />
         )}
 
-        {/* Current Images Display (from form context) */}
-        {currentContext &&
-          Array.isArray(currentContext) &&
-          currentContext.length > 0 &&
-          selectedImages.length === 0 && (
-            <div className="space-y-3">
-              <Label>Current Images ({currentContext.length})</Label>
-              <div className="grid max-h-60 grid-cols-2 gap-4 overflow-y-auto rounded-lg md:grid-cols-3">
-                {currentContext.map((item, index) => (
-                  <div key={`current-${index}`} className="relative">
-                    {item instanceof File ? (
-                      <>
-                        <div className="aspect-square overflow-hidden rounded-lg border border-dashed border-gray-200">
-                          <Image
-                            width={150}
-                            height={150}
-                            src={URL.createObjectURL(item)}
-                            alt={`Current ${item.name}`}
-                            className="h-full w-full object-cover"
-                          />
-                        </div>
-                        <div className="absolute right-0 bottom-0 left-0 truncate bg-black/50 p-1 text-xs text-white">
-                          {item.name}
-                        </div>
-                        <div className="mt-1 text-center text-xs text-gray-500">
-                          {(item.size / 1024).toFixed(1)} KB
-                        </div>
-                      </>
-                    ) : (
-                      <div className="flex aspect-square items-center justify-center rounded-lg border-2 border-gray-200">
-                        <div className="text-center text-sm text-gray-500">
-                          Unknown format
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
         {/* Action Buttons */}
-        <div className="flex items-center justify-between pt-4">
+        <div className="flex flex-col items-center justify-between gap-4 pt-4 md:flex-row">
           <div className="text-sm text-gray-300">
             {selectedImages.length > 0 &&
               `${selectedImages.length} image(s) selected`}

--- a/features/test/components/question-image.tsx
+++ b/features/test/components/question-image.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useToolbarStore } from "@/store/toolbar-store";
+import { Upload, X } from "lucide-react";
+import Image from "next/image";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+type QuestionImageProps = {
+  isDialogOpen: boolean;
+  setIsDialogOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onDialogOpenChange: (isOpen: boolean) => void;
+};
+
+interface ImageItem {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+const QuestionImage = ({
+  isDialogOpen,
+  setIsDialogOpen,
+  onDialogOpenChange,
+}: QuestionImageProps) => {
+  const { setValue, watch } = useFormContext();
+  const { activePassageIndex, activeQuestionGroupIndex, activeQuestionIndex } =
+    useToolbarStore();
+
+  const imagePath = `passages.${activePassageIndex}.questionGroups.${activeQuestionGroupIndex}.questions.${activeQuestionIndex}.question_data.images`;
+  const currentContext = watch(imagePath);
+
+  const [selectedImages, setSelectedImages] = useState<ImageItem[]>([]);
+  const previousDialogState = useRef<boolean>(false);
+
+  // Load existing images from context only when context changes
+  useEffect(() => {
+    if (currentContext && Array.isArray(currentContext)) {
+      const loadedImages: ImageItem[] = [];
+      currentContext.forEach((item, index) => {
+        if (item instanceof File) {
+          loadedImages.push({
+            id: `existing-${index}`,
+            file: item,
+            previewUrl: URL.createObjectURL(item),
+          });
+        }
+      });
+      setSelectedImages(loadedImages);
+    } else {
+      setSelectedImages([]);
+    }
+  }, [currentContext]);
+
+  // Handle dialog close/open changes
+  useEffect(() => {
+    // Only reset when dialog actually closes (was open, now closed)
+    if (previousDialogState.current && !isDialogOpen) {
+      // Reset state when dialog closes
+      setSelectedImages((prevImages) => {
+        // Cleanup blob URLs
+        prevImages.forEach((img) => {
+          if (img.previewUrl.startsWith("blob:")) {
+            URL.revokeObjectURL(img.previewUrl);
+          }
+        });
+        return [];
+      });
+    }
+
+    // Update previous state
+    previousDialogState.current = isDialogOpen;
+  }, [isDialogOpen]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      selectedImages.forEach((img) => {
+        if (img.previewUrl.startsWith("blob:")) {
+          URL.revokeObjectURL(img.previewUrl);
+        }
+      });
+    };
+  }, [selectedImages]);
+
+  const generateId = () =>
+    `img-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+
+    const newImages: ImageItem[] = imageFiles.map((file) => ({
+      id: generateId(),
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+
+    setSelectedImages((prev) => [...prev, ...newImages]);
+
+    // Reset input value so same file can be selected again
+    e.target.value = "";
+  };
+
+  const handleRemoveImage = useCallback((id: string) => {
+    setSelectedImages((prev) => {
+      const imageToRemove = prev.find((img) => img.id === id);
+      if (imageToRemove && imageToRemove.previewUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(imageToRemove.previewUrl);
+      }
+      return prev.filter((img) => img.id !== id);
+    });
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    setSelectedImages((prevImages) => {
+      // Cleanup blob URLs
+      prevImages.forEach((img) => {
+        if (img.previewUrl.startsWith("blob:")) {
+          URL.revokeObjectURL(img.previewUrl);
+        }
+      });
+      return [];
+    });
+  }, []);
+
+  const handleSaveImages = useCallback(() => {
+    // Save array of File objects to form context
+    const files = selectedImages.map((img) => img.file);
+    setValue(imagePath, files, {
+      shouldDirty: true,
+      shouldTouch: true,
+    });
+
+    setIsDialogOpen(false);
+  }, [selectedImages, setValue, imagePath, setIsDialogOpen]);
+
+  const handleDialogContentClick = (e: React.MouseEvent) => {
+    // Prevent dialog from closing when clicking inside dialog content
+    e.stopPropagation();
+  };
+
+  return (
+    <DialogContent
+      className="overflow-y-auto border-none"
+      onClick={handleDialogContentClick}
+      data-image-dialog="true"
+      onOpenAutoFocus={(e) => e.preventDefault()}
+    >
+      <DialogHeader>
+        <DialogTitle>Add Images</DialogTitle>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        {/* File Upload */}
+        <div className="space-y-3">
+          <Label htmlFor="image-files" className="text-sm">
+            Upload Image Files
+          </Label>
+          <Label
+            htmlFor="image-files"
+            className="text-foreground flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 p-6 text-center transition"
+          >
+            <Upload className="mb-2 h-8 w-8" />
+            <span className="text-sm">Click to upload or drag & drop</span>
+            <span className="mt-1 text-xs">PNG, JPG, JPEG</span>
+            <Input
+              id="image-files"
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={handleFileChange}
+              className="hidden"
+            />
+          </Label>
+          <p className="text-xs text-gray-300">
+            You can select multiple images at once
+          </p>
+        </div>
+
+        {/* Selected Images Preview */}
+        {selectedImages.length > 0 && (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label>Selected Images ({selectedImages.length})</Label>
+              <Button
+                type="button"
+                variant="outline"
+                size="xsm"
+                onClick={handleClearAll}
+              >
+                <X className="mr-1 h-4 w-4" />
+                Clear All
+              </Button>
+            </div>
+            <div className="grid max-h-60 grid-cols-2 gap-4 overflow-y-auto rounded-lg p-2 md:grid-cols-3">
+              {selectedImages.map((imageItem) => (
+                <div key={imageItem.id} className="group relative">
+                  <div className="aspect-square overflow-hidden rounded-lg border-2 border-dashed border-gray-300">
+                    <Image
+                      width={150}
+                      height={150}
+                      src={imageItem.previewUrl}
+                      alt={`Preview ${imageItem.file.name}`}
+                      className="h-full w-full object-cover"
+                      onError={() => {
+                        console.error(
+                          `Failed to load image: ${imageItem.file.name}`,
+                        );
+                      }}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="iconSm"
+                    className="absolute -top-2 -right-2 h-6 w-6 rounded-full p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                    onClick={() => handleRemoveImage(imageItem.id)}
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                  <div className="absolute right-0 bottom-0 left-0 truncate bg-black/50 p-1 text-xs text-white">
+                    {imageItem.file.name}
+                  </div>
+                  <div className="mt-1 text-center text-xs text-gray-500">
+                    {(imageItem.file.size / 1024).toFixed(1)} KB
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Current Images Display (from form context) */}
+        {currentContext &&
+          Array.isArray(currentContext) &&
+          currentContext.length > 0 &&
+          selectedImages.length === 0 && (
+            <div className="space-y-3">
+              <Label>Current Images ({currentContext.length})</Label>
+              <div className="grid max-h-60 grid-cols-2 gap-4 overflow-y-auto rounded-lg md:grid-cols-3">
+                {currentContext.map((item, index) => (
+                  <div key={`current-${index}`} className="relative">
+                    {item instanceof File ? (
+                      <>
+                        <div className="aspect-square overflow-hidden rounded-lg border border-dashed border-gray-200">
+                          <Image
+                            width={150}
+                            height={150}
+                            src={URL.createObjectURL(item)}
+                            alt={`Current ${item.name}`}
+                            className="h-full w-full object-cover"
+                          />
+                        </div>
+                        <div className="absolute right-0 bottom-0 left-0 truncate bg-black/50 p-1 text-xs text-white">
+                          {item.name}
+                        </div>
+                        <div className="mt-1 text-center text-xs text-gray-500">
+                          {(item.size / 1024).toFixed(1)} KB
+                        </div>
+                      </>
+                    ) : (
+                      <div className="flex aspect-square items-center justify-center rounded-lg border-2 border-gray-200">
+                        <div className="text-center text-sm text-gray-500">
+                          Unknown format
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+        {/* Action Buttons */}
+        <div className="flex items-center justify-between pt-4">
+          <div className="text-sm text-gray-300">
+            {selectedImages.length > 0 &&
+              `${selectedImages.length} image(s) selected`}
+          </div>
+          <div className="flex space-x-2">
+            <Button
+              type="button"
+              size="xsm"
+              variant="outline"
+              onClick={() => onDialogOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="xsm"
+              onClick={handleSaveImages}
+              disabled={selectedImages.length === 0}
+            >
+              Save Images ({selectedImages.length})
+            </Button>
+          </div>
+        </div>
+      </div>
+    </DialogContent>
+  );
+};
+
+export default QuestionImage;

--- a/features/test/components/questions/choose-correct-answer.tsx
+++ b/features/test/components/questions/choose-correct-answer.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { extractIndexes } from "@/helpers/extract-indexes";
+import { ImagePreview } from "../question-image";
 
 type OptionType = {
   option_key: string;
@@ -50,6 +51,10 @@ const ChooseCorrectAnswer = ({
   const questionOptions = watch(`${questionPath}.options`) as OptionType[];
 
   const answer = watch(`${questionPath}.correct_answer`);
+  
+  const currentImages = watch(
+    `${questionsPath}.${qIndex}.question_data.images`,
+  );
 
   return (
     <div className="space-y-6">
@@ -63,6 +68,14 @@ const ChooseCorrectAnswer = ({
           groupIndex={questionGroupIndex}
           globalNumber={globalNumber}
         />
+
+        <div className="mx-auto max-w-md">
+          <ImagePreview
+            images={currentImages}
+            showActions={false}
+            containerClassName="grid-cols-3 md:grid-cols-4"
+          />
+        </div>
 
         <OptionFieldArray
           questionsPath={`${questionPath}.options`}

--- a/features/test/components/questions/choose-multiple-answer.tsx
+++ b/features/test/components/questions/choose-multiple-answer.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { extractIndexes } from "@/helpers/extract-indexes";
+import { ImagePreview } from "../question-image";
 
 type OptionType = {
   option_key: string;
@@ -50,6 +51,10 @@ const ChooseMultipleAnswer = ({
   const questionOptions = watch(`${questionPath}.options`) as OptionType[];
 
   const answer = watch(`${questionPath}.correct_answer`);
+  
+  const currentImages = watch(
+    `${questionsPath}.${qIndex}.question_data.images`,
+  );
 
   return (
     <div className="space-y-6">
@@ -63,6 +68,14 @@ const ChooseMultipleAnswer = ({
           groupIndex={questionGroupIndex}
           globalNumber={globalNumber}
         />
+
+        <div className="mx-auto max-w-md">
+          <ImagePreview
+            images={currentImages}
+            showActions={false}
+            containerClassName="grid-cols-3 md:grid-cols-4"
+          />
+        </div>
 
         <OptionFieldArray
           questionsPath={`${questionPath}.options`}

--- a/features/test/components/questions/true-false-not-given.tsx
+++ b/features/test/components/questions/true-false-not-given.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { extractIndexes } from "@/helpers/extract-indexes";
+import { ImagePreview } from "../question-image";
 
 type OptionType = {
   option_key: string;
@@ -47,6 +48,10 @@ const TrueFalseNotGiven = ({
     name: questionsPath,
   });
 
+  const currentImages = watch(
+    `${questionsPath}.${qIndex}.question_data.images`,
+  );
+
   const questionOptions = watch(
     `${questionsPath}.${qIndex}.options`,
   ) as OptionType[];
@@ -65,6 +70,14 @@ const TrueFalseNotGiven = ({
           groupIndex={questionGroupIndex}
           globalNumber={globalNumber}
         />
+
+        <div className="mx-auto max-w-md">
+          <ImagePreview
+            images={currentImages}
+            showActions={false}
+            containerClassName="grid-cols-3 md:grid-cols-4"
+          />
+        </div>
 
         <OptionFieldArray
           questionsPath={`${questionPath}.options`}

--- a/features/test/components/questions/yes-no-not-given.tsx
+++ b/features/test/components/questions/yes-no-not-given.tsx
@@ -17,6 +17,7 @@ import { extractIndexes } from "@/helpers/extract-indexes";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { FaTrash } from "react-icons/fa";
 import { PiCopyFill } from "react-icons/pi";
+import { ImagePreview } from "../question-image";
 
 type OptionType = {
   option_key: string;
@@ -47,6 +48,10 @@ const YesNoNotGiven = ({
     name: questionsPath,
   });
 
+  const currentImages = watch(
+    `${questionsPath}.${qIndex}.question_data.images`,
+  );
+
   const questionOptions = watch(
     `${questionsPath}.${qIndex}.options`,
   ) as OptionType[];
@@ -65,6 +70,14 @@ const YesNoNotGiven = ({
           groupIndex={questionGroupIndex}
           globalNumber={globalNumber}
         />
+
+        <div className="mx-auto max-w-md">
+          <ImagePreview
+            images={currentImages}
+            showActions={false}
+            containerClassName="grid-cols-3 md:grid-cols-4"
+          />
+        </div>
 
         <OptionFieldArray
           questionsPath={`${questionPath}.options`}

--- a/features/test/components/toolbar.tsx
+++ b/features/test/components/toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import {
   Tooltip,
   TooltipContent,
@@ -9,14 +9,17 @@ import {
 } from "@/components/ui/tooltip";
 import { QuestionType } from "@/types/test";
 import { AlignLeft, Plus, ShieldQuestionMark, Sparkle } from "lucide-react";
-import React from "react";
+import React, { useState } from "react";
 import { BiSolidImage } from "react-icons/bi";
+import { TbSection } from "react-icons/tb";
+import QuestionImage from "./question-image";
 
 interface ToolbarProps {
   onAddQuestion: () => void;
   onAddPassage: () => void;
   onAddQustionGroup?: (questionType: QuestionType) => void;
   isActive?: boolean;
+  variant?: "reading" | "listening";
 }
 
 const Toolbar = ({
@@ -24,7 +27,10 @@ const Toolbar = ({
   onAddPassage,
   isActive = false,
   onAddQustionGroup,
+  variant = "reading",
 }: ToolbarProps) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
   if (!isActive) return null;
 
   const handleToolbarClick = (e: React.MouseEvent) => {
@@ -32,9 +38,13 @@ const Toolbar = ({
     e.stopPropagation();
   };
 
+  const handleDialogOpenChange = (open: boolean) => {
+    setIsDialogOpen(open);
+  };
+
   return (
     <div
-      className="absolute top-1/2 -right-4 z-0 flex -translate-y-1/2 flex-col gap-4.5 rounded-full bg-[#E0E9D8] px-1.5 py-4 shadow-lg md:-right-8 md:px-2.5"
+      className="absolute top-1/2 -right-4 z-10 flex -translate-y-1/2 flex-col gap-4.5 rounded-full bg-[#E0E9D8] px-1.5 py-4 shadow-lg md:-right-8 md:px-2.5"
       data-toolbar="true"
       onClick={handleToolbarClick}
     >
@@ -95,7 +105,11 @@ const Toolbar = ({
         </TooltipContent>
       </Tooltip>
 
-      <Dialog>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={handleDialogOpenChange}
+        modal={true}
+      >
         <Tooltip>
           <TooltipTrigger asChild>
             <DialogTrigger asChild>
@@ -116,7 +130,11 @@ const Toolbar = ({
           </TooltipContent>
         </Tooltip>
 
-        <DialogContent>{/* Isi dialog di sini */}</DialogContent>
+        <QuestionImage
+          isDialogOpen={isDialogOpen}
+          setIsDialogOpen={setIsDialogOpen}
+          onDialogOpenChange={handleDialogOpenChange}
+        />
       </Dialog>
 
       <Tooltip>
@@ -130,11 +148,11 @@ const Toolbar = ({
               onAddPassage();
             }}
           >
-            <AlignLeft />
+            {variant === "reading" ? <AlignLeft /> : <TbSection />}
           </Button>
         </TooltipTrigger>
         <TooltipContent side="left">
-          <p>Add Passage</p>
+          <p>Add {variant === "reading" ? "Passage" : "Section"}</p>
         </TooltipContent>
       </Tooltip>
     </div>

--- a/features/test/form/create-listening-form.ts
+++ b/features/test/form/create-listening-form.ts
@@ -15,6 +15,12 @@ export const breakdownSchema = z.object({
   explanation: z.string().optional(),
 });
 
+export const questionDataSchema = z.object({
+  images: z
+    .array(z.instanceof(File, { message: "Each image must be a valid file" }))
+    .optional(),
+});
+
 const chooseCorrectAnswerSchema = z.object({
   question_number: z.number({
     required_error: "Question number is required",
@@ -25,6 +31,7 @@ const chooseCorrectAnswerSchema = z.object({
   correct_answer: optionSchema,
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 
@@ -38,6 +45,7 @@ const chooseMultipleAnswerSchema = z.object({
   correct_answer: z.array(optionSchema).min(1).max(2),
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 

--- a/features/test/form/create-reading-form.ts
+++ b/features/test/form/create-reading-form.ts
@@ -17,6 +17,12 @@ export const QuestionType = z.enum([
   // "note_completion",
 ]);
 
+export const questionDataSchema = z.object({
+  images: z
+    .array(z.instanceof(File, { message: "Each image must be a valid file" }))
+    .optional(),
+});
+
 const optionSchema = z.object({
   option_key: z.string().min(1, "Option key is required"),
   option_text: z.string().min(1, "Option text is required"),
@@ -42,6 +48,7 @@ const chooseCorrectAnswerSchema = z.object({
   correct_answer: optionSchema,
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 
@@ -55,6 +62,7 @@ const chooseMultipleAnswerSchema = z.object({
   correct_answer: z.array(optionSchema).min(1).max(2),
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 
@@ -68,6 +76,7 @@ const trueFalseNotGiven = z.object({
   correct_answer: optionSchema,
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 
@@ -97,6 +106,7 @@ const yesNoNotGiven = z.object({
   correct_answer: optionSchema,
   options: z.array(optionSchema).min(2, "At least 2 options are required"),
   points_value: z.number().min(1, "Points value must be at least 1"),
+  question_data: questionDataSchema.optional(),
   breakdown: breakdownSchema.optional(),
 });
 

--- a/features/test/listening/components/passage-section.tsx
+++ b/features/test/listening/components/passage-section.tsx
@@ -73,7 +73,7 @@ export const PassageSection = ({
         <div className="flex justify-between">
           <div className="flex gap-[50px]">
             <div className="flex w-[156px] items-center justify-start border-r border-[#dedede]">
-              <p className="typoSubHeadlines">Passage {index + 1}</p>
+              <p className="typoSubHeadlines">Section {index + 1}</p>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/features/test/listening/components/questions-section.tsx
+++ b/features/test/listening/components/questions-section.tsx
@@ -21,9 +21,9 @@ import {
 import React, { useCallback, useEffect, useRef } from "react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { MdDragIndicator } from "react-icons/md";
+import Toolbar from "@/features/test/components/toolbar";
 import { defaultListeningQuestion } from "../../constant/default-listening-question";
 import { PassageListening } from "../../form/create-listening-form";
-import Toolbar from "../../reading/components/toolbar";
 
 type QuestionsSectionProps = {
   nestIndex: number;
@@ -185,9 +185,19 @@ export const QuestionsSection = ({
         target.closest('[role="listbox"]') ||
         target.closest("[data-radix-select-content]") ||
         target.closest("[data-radix-popper-content-wrapper]");
+      const isDialogClick =
+        target.closest("[data-radix-dialog-content]") ||
+        target.closest("[role='dialog']") ||
+        target.closest(".dialog-content");
       const isContainerClick = questionsContainerRef.current?.contains(target);
 
-      if (!isToolbarClick && !isSelectClick && !isContainerClick) {
+      // Don't clear active state if clicking on dialog, toolbar, select, or container
+      if (
+        !isToolbarClick &&
+        !isSelectClick &&
+        !isDialogClick &&
+        !isContainerClick
+      ) {
         clearActive();
       }
     };
@@ -267,6 +277,7 @@ export const QuestionsSection = ({
                         onAddQuestion={handleAddQuestion}
                         onAddPassage={onAddPassage}
                         onAddQustionGroup={onAddQuestionGroup}
+                        variant="listening"
                       />
                     )}
 

--- a/features/test/reading/components/questions-section.tsx
+++ b/features/test/reading/components/questions-section.tsx
@@ -19,7 +19,7 @@ import {
 import React, { useCallback, useEffect, useRef } from "react";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { MdDragIndicator } from "react-icons/md";
-import Toolbar from "./toolbar";
+import Toolbar from "@/features/test/components/toolbar";
 import { defaultReadingQuestion } from "../../constant/default-reading-question";
 // import ChooseMultipleAnswer from "./questions/choose-multiple-answer";
 // import DiagramLabelCompletion from "./questions/diagram-label-completion";
@@ -208,9 +208,19 @@ export const QuestionsSection = ({
         target.closest('[role="listbox"]') ||
         target.closest("[data-radix-select-content]") ||
         target.closest("[data-radix-popper-content-wrapper]");
+      const isDialogClick =
+        target.closest("[data-radix-dialog-content]") ||
+        target.closest("[role='dialog']") ||
+        target.closest(".dialog-content");
       const isContainerClick = questionsContainerRef.current?.contains(target);
 
-      if (!isToolbarClick && !isSelectClick && !isContainerClick) {
+      // Don't clear active state if clicking on dialog, toolbar, select, or container
+      if (
+        !isToolbarClick &&
+        !isSelectClick &&
+        !isDialogClick &&
+        !isContainerClick
+      ) {
         clearActive();
       }
     };


### PR DESCRIPTION
- Fix runtime error "Cannot update component while rendering" by removing setValue calls from useCallback functions that trigger during render
- Fix duplicate image issue by loading existing images only when dialog opens instead of on context changes
- Simplify UI logic to use single ImagePreview component for selected images
- Add proper dialog cancel handler that resets to original state
- Remove premature form context updates - only update on save/cancel actions
- Improve dialog UX by showing current saved images count when no images selected

Fixes image deletion not working and prevents React setState-in-render warnings.