### PR TITLE
feat: dockerize frontend + CI deploy via GitHub Actions 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+node_modules
+.next/cache
+*.log
+.DS_Store

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,38 @@
+name: Deploy Frontend
+
+on:
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.VPS_SSH_KEY }}
+
+      - name: Copy Docker files to VPS
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} 'mkdir -p /srv/apps/koupii-frontend'
+          scp -o StrictHostKeyChecking=no Dockerfile.frontend root@${{ secrets.VPS_HOST }}:/srv/apps/koupii-frontend/
+          scp -o StrictHostKeyChecking=no docker-compose.yml root@${{ secrets.VPS_HOST }}:/srv/apps/koupii-frontend/
+
+      - name: Sync source to VPS current
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} 'mkdir -p /srv/apps/koupii-frontend/current'
+          rsync -az --delete -e "ssh -o StrictHostKeyChecking=no" ./ root@${{ secrets.VPS_HOST }}:/srv/apps/koupii-frontend/current
+
+      - name: Build & Up (parallel to current manual app)
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} '
+            cd /srv/apps/koupii-frontend && docker compose build --no-cache && docker compose up -d
+          '
+
+      - name: Health check container
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} 'curl -sf http://127.0.0.1:8082/ | head -20 > /dev/null'

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -27,6 +27,13 @@ jobs:
           ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} 'mkdir -p /srv/apps/koupii-frontend/current'
           rsync -az --delete -e "ssh -o StrictHostKeyChecking=no" ./ root@${{ secrets.VPS_HOST }}:/srv/apps/koupii-frontend/current
 
+      - name: Inject env (optional)
+        if: ${{ secrets.NEXT_PUBLIC_BACKEND_URL != '' }}
+        run: |
+          ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} "bash -lc 'cat > /srv/apps/koupii-frontend/current/.env <<EOF
+NEXT_PUBLIC_BACKEND_URL=${{ secrets.NEXT_PUBLIC_BACKEND_URL }}
+EOF'"
+
       - name: Build & Up (parallel to current manual app)
         run: |
           ssh -o StrictHostKeyChecking=no root@${{ secrets.VPS_HOST }} '

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,29 @@
+# Dockerfile.frontend
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* pnpm-lock.yaml* yarn.lock* ./
+RUN \
+  if [ -f package-lock.json ]; then npm ci --no-audit --no-fund; \
+  elif [ -f yarn.lock ]; then yarn --frozen-lockfile; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable && pnpm i --frozen-lockfile; \
+  else npm i --no-audit --no-fund; fi
+
+FROM node:20-alpine AS build
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+# Build Next.js; standalone runtime
+RUN npx next build --no-lint && \
+    mkdir -p .next/standalone/public && \
+    cp -r public .next/standalone/public || true && \
+    cp -r .next/static .next/standalone/.next/static
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+# USER node  # optional non-root
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/public ./public
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  frontend:
+    build:
+      context: ./current
+      dockerfile: ../Dockerfile.frontend
+    container_name: koupii-frontend
+    restart: unless-stopped
+    ports:
+      - "8082:3000"
+    environment:
+      - NODE_ENV=production
+    networks:
+      - koupii-network
+
+networks:
+  koupii-network:
+    driver: bridge

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,12 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
   images: {
-    domains: ["images.unsplash.com", "plus.unsplash.com"],
+    remotePatterns: [
+      { protocol: "https", hostname: "images.unsplash.com" },
+      { protocol: "https", hostname: "plus.unsplash.com" },
+    ],
   },
 };
 const withNextIntl = createNextIntlPlugin();


### PR DESCRIPTION
PR descriptions:

- Ringkasan
1. Dockerize Next.js dengan output standalone
2. Tambah docker-compose (port 8082) untuk parallel run tanpa downtime
3. Tambah GitHub Actions: rsync → build → up → health check
4. Update next.config.ts: output=standalone, images.remotePatterns

- Perubahan utama
1. Dockerfile.frontend
2. docker-compose.yml
3. .dockerignore
4. .github/workflows/deploy-frontend.yml
5. next.config.ts